### PR TITLE
chore: consolidate, docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -19,10 +19,7 @@
   [Nordth](https://github.com/Nordth).
 - Unicode-derived tables are generated at build time; no network traffic occurs at runtime.
 
-## Documentation Map
+## Documentation
 
-- Rust library semantics: [API Reference](api.md)
-- CLI behavior and flags: [CLI Guide](cli.md)
-- Rust usage recipes: [Examples](examples.md)
-- Python package docs: [python/docs/index.md](../python/docs/index.md)
-- Python release automation + PyPI flow: [python/docs/release.md](../python/docs/release.md)
+- Rust docs index: [README](../README.md#documentation)
+- Python docs index: [python/docs/index.md](../python/docs/index.md)

--- a/python/README.md
+++ b/python/README.md
@@ -18,19 +18,20 @@ See [python/docs/index.md](docs/index.md) for the Python docs map.
 
 ## Quickstart
 
-`clean()` and `humanize()` both return `str`, but they use different defaults:
+`clean()` and `humanize()` both return `str`, but they target different outputs:
 
-| Helper | Default behavior |
-| --- | --- |
-| `clean(text)` | Keyboard-safe output (`keyboard_only=True`), transliterates non-ASCII when feasible |
-| `humanize(text)` | Human-readable Unicode output (`keyboard_only=False`), collapses whitespace |
+- `clean(text)`: ASCII/keyboard-safe text (drops emoji by default, transliterates when feasible)
+- `humanize(text)`: human-readable Unicode text (keeps Unicode, collapses repeated whitespace)
 
 ```python
 import rehuman
 
 text = "A   B 👍 Café"
-assert rehuman.clean(text) == "A   B Cafe"
-assert rehuman.humanize(text) == "A B 👍 Café"
+cleaned = rehuman.clean(text)       # "A   B Cafe"
+humanized = rehuman.humanize(text)  # "A B 👍 Café"
+
+assert cleaned == "A   B Cafe"
+assert humanized == "A B 👍 Café"
 
 # Use Cleaner for change counts and stats
 cleaner = rehuman.Cleaner()
@@ -40,8 +41,10 @@ print(result.changes_made) # e.g. 3
 print(result.stats)        # dict with per-operation counters
 ```
 
-For custom options (`non_ascii_policy`, `extended_keyboard`, `preserve_joiners`,
-presets), see [python/docs/api.md](docs/api.md#options).
+For exact behavior differences and presets, see:
+
+- [clean vs humanize](docs/api.md#clean-vs-humanize)
+- [Options](docs/api.md#options)
 
 ## Tests
 

--- a/python/docs/index.md
+++ b/python/docs/index.md
@@ -7,9 +7,3 @@ Python package documentation for `import rehuman`.
 - [API Reference](api.md): functions, classes, presets, constants, and errors.
 - [Release Automation](release.md): wheel/sdist release assets and PyPI publish flows.
 - [Package README](../README.md): local install, quickstart, and test commands.
-
-## Common Tasks
-
-- Compare `clean()` vs `humanize()`: [API comparison](api.md#clean-vs-humanize)
-- Configure options and presets: [Options class](api.md#options)
-- Run local build/test loop: [README](../README.md#install-development)

--- a/src/bin/common/mod.rs
+++ b/src/bin/common/mod.rs
@@ -4,17 +4,17 @@
 //! streaming glue, and stats serialization used by both binaries.
 
 use std::fs;
-use std::io::{self, BufRead, IsTerminal, Read, Write};
+use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
-use clap::ValueEnum;
+use clap::{Args, ValueEnum};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
 use rehuman::{
     CleaningOptions, CleaningResult, CleaningStats, EmojiPolicy, LineEndingStyle, NonAsciiPolicy,
-    StreamCleaner, TextCleaner, UnicodeNormalizationMode,
+    UnicodeNormalizationMode,
 };
 
 /// Maximum input size accepted by non-streaming paths.
@@ -254,6 +254,135 @@ impl PartialOptions {
     }
 }
 
+/// Shared CLI argument surface used by both `rehuman` and `ishuman`.
+#[derive(Args, Debug)]
+pub struct SharedCliOptions {
+    /// Apply a named preset (for example `code-safe` for docs/source text).
+    #[arg(long, value_enum)]
+    pub preset: Option<PresetArg>,
+
+    /// Override remove_hidden behavior (true/false, default true)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub remove_hidden: Option<bool>,
+
+    /// Override remove_trailing_whitespace behavior (true/false, default true)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub remove_trailing_whitespace: Option<bool>,
+
+    /// Override normalize_spaces behavior (true/false, default true)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub normalize_spaces: Option<bool>,
+
+    /// Override normalize_dashes behavior (true/false, default true)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub normalize_dashes: Option<bool>,
+
+    /// Override normalize_quotes behavior (true/false, default true)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub normalize_quotes: Option<bool>,
+
+    /// Override normalize_other behavior (true/false, default true)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub normalize_other: Option<bool>,
+
+    /// Override keyboard_only behavior (true/false, default true for CLI)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub keyboard_only: Option<bool>,
+
+    /// Allow a curated non-ASCII keyboard allowlist in keyboard-only mode.
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub extended_keyboard: Option<bool>,
+
+    /// Allow emoji to pass through even when keyboard_only is enabled
+    #[arg(long, action = clap::ArgAction::SetTrue, conflicts_with = "emoji_policy")]
+    pub keep_emoji: bool,
+
+    /// Explicit emoji policy (drop or keep)
+    #[arg(long, value_enum)]
+    pub emoji_policy: Option<EmojiPolicyArg>,
+
+    /// Non-ASCII handling in keyboard-only mode (drop/fold/transliterate).
+    #[arg(long, value_enum)]
+    pub non_ascii_policy: Option<NonAsciiPolicyArg>,
+
+    /// Preserve ZWJ/ZWNJ joiners even when hidden characters are removed.
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub preserve_joiners: Option<bool>,
+
+    /// Override remove_control_chars behavior (true/false, default true)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub remove_control_chars: Option<bool>,
+
+    /// Override collapse_whitespace behavior (true/false, default false)
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub collapse_whitespace: Option<bool>,
+
+    /// Line ending normalization strategy (auto = preserve input)
+    #[arg(long, value_enum)]
+    pub line_endings: Option<LineEndingChoice>,
+
+    /// Unicode normalization mode (none/NFD/NFC/NFKD/NFKC)
+    #[arg(long, value_enum)]
+    pub unicode_normalization: Option<UnicodeNormalizationChoice>,
+
+    /// Strip bidi control characters (true/false, default false)
+    #[cfg(feature = "security")]
+    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
+    pub strip_bidi_controls: Option<bool>,
+
+    /// Path to config file. Defaults to platform config directory.
+    #[arg(long, value_name = "PATH")]
+    pub config: Option<PathBuf>,
+}
+
+impl SharedCliOptions {
+    /// Convert shared CLI flags into sparse option overrides.
+    pub fn to_partial_options(&self) -> PartialOptions {
+        let mut partial = PartialOptions {
+            remove_hidden: self.remove_hidden,
+            remove_trailing_whitespace: self.remove_trailing_whitespace,
+            normalize_spaces: self.normalize_spaces,
+            normalize_dashes: self.normalize_dashes,
+            normalize_quotes: self.normalize_quotes,
+            normalize_other: self.normalize_other,
+            keyboard_only: self.keyboard_only,
+            extended_keyboard: self.extended_keyboard,
+            emoji_policy: None,
+            non_ascii_policy: self.non_ascii_policy,
+            preserve_joiners: self.preserve_joiners,
+            remove_control_chars: self.remove_control_chars,
+            collapse_whitespace: self.collapse_whitespace,
+            line_endings: self.line_endings,
+            unicode_normalization: self.unicode_normalization,
+            #[cfg(feature = "security")]
+            strip_bidi_controls: self.strip_bidi_controls,
+        };
+
+        if self.keep_emoji {
+            partial.emoji_policy = Some(EmojiPolicyArg::Keep);
+        } else if let Some(policy) = self.emoji_policy {
+            partial.emoji_policy = Some(policy);
+        }
+
+        partial
+    }
+
+    /// Whether emoji policy controls were explicitly specified.
+    pub fn emoji_policy_specified_by_user(&self) -> bool {
+        self.keep_emoji || self.emoji_policy.is_some()
+    }
+
+    /// Whether non-ASCII policy was explicitly specified.
+    pub fn non_ascii_policy_specified_by_user(&self) -> bool {
+        self.non_ascii_policy.is_some()
+    }
+
+    /// Whether extended keyboard mode was explicitly specified.
+    pub fn extended_keyboard_specified_by_user(&self) -> bool {
+        self.extended_keyboard.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
@@ -415,12 +544,11 @@ pub fn validate_emoji_policy_dependency(
     options: &CleaningOptions,
     emoji_policy_specified_by_user: bool,
 ) -> Result<()> {
-    if emoji_policy_specified_by_user && !options.keyboard_only {
-        bail!(
-            "'--keep-emoji'/'--emoji-policy' require keyboard-only mode; set '--keyboard-only true' or remove emoji policy flags"
-        );
-    }
-    Ok(())
+    validate_keyboard_only_dependency(
+        options,
+        emoji_policy_specified_by_user,
+        "'--keep-emoji'/'--emoji-policy'",
+    )
 }
 
 /// Validate that explicit non-ASCII handling is meaningful.
@@ -442,12 +570,11 @@ pub fn validate_non_ascii_policy_dependency(
     options: &CleaningOptions,
     non_ascii_policy_specified_by_user: bool,
 ) -> Result<()> {
-    if non_ascii_policy_specified_by_user && !options.keyboard_only {
-        bail!(
-            "'--non-ascii-policy' requires keyboard-only mode; set '--keyboard-only true' or remove the non-ASCII policy flag"
-        );
-    }
-    Ok(())
+    validate_keyboard_only_dependency(
+        options,
+        non_ascii_policy_specified_by_user,
+        "'--non-ascii-policy'",
+    )
 }
 
 /// Validate that explicit extended keyboard mode is meaningful.
@@ -469,39 +596,11 @@ pub fn validate_extended_keyboard_dependency(
     options: &CleaningOptions,
     extended_keyboard_specified_by_user: bool,
 ) -> Result<()> {
-    if extended_keyboard_specified_by_user && !options.keyboard_only {
-        bail!(
-            "'--extended-keyboard' requires keyboard-only mode; set '--keyboard-only true' or remove the extended keyboard flag"
-        );
-    }
-    Ok(())
-}
-
-#[allow(dead_code)]
-/// Persist config to disk, creating parent directories as needed.
-///
-/// # Arguments
-/// - `path`: Destination config path.
-/// - `options`: Runtime options snapshot to serialize.
-///
-/// # Returns
-/// `Ok(())` once config is written.
-///
-/// # Errors
-/// Returns an error if directories cannot be created, serialization fails, or
-/// the file cannot be written.
-pub fn save_config(path: &Path, options: &CleaningOptions) -> Result<()> {
-    let cfg = ConfigFile {
-        version: CONFIG_VERSION,
-        options: SerializableOptions::from_cleaning_options(options),
-    };
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create config directory {}", parent.display()))?;
-    }
-    let data = toml::to_string_pretty(&cfg)?;
-    fs::write(path, data)?;
-    Ok(())
+    validate_keyboard_only_dependency(
+        options,
+        extended_keyboard_specified_by_user,
+        "'--extended-keyboard'",
+    )
 }
 
 /// Read input text from a path or stdin with size checks.
@@ -550,22 +649,6 @@ pub fn read_input(input_path: Option<&Path>, max_bytes: usize) -> Result<String>
     }
 }
 
-#[allow(dead_code)]
-/// Write cleaned text to stdout.
-///
-/// # Returns
-/// `Ok(())` when output is written.
-///
-/// # Errors
-/// Returns an error if writing to stdout fails.
-pub fn write_output(result: &CleaningResult<'_>) -> Result<()> {
-    let mut stdout = io::stdout().lock();
-    stdout
-        .write_all(result.text.as_bytes())
-        .context("failed to write to stdout")?;
-    Ok(())
-}
-
 /// Emit human-readable stats to stderr.
 pub fn write_stats(result: &CleaningResult<'_>) {
     let stats = &result.stats;
@@ -607,14 +690,6 @@ pub fn parse_bool_flag(value: &str) -> std::result::Result<bool, String> {
     }
 }
 
-#[allow(dead_code)]
-#[derive(Debug)]
-/// Aggregate output produced by streaming cleanup.
-pub struct StreamOutcome {
-    pub stats: CleaningStats,
-    pub changes_made: u64,
-}
-
 #[derive(Serialize)]
 /// JSON-serializable summary payload for stats output.
 pub struct StatsSummary<'a> {
@@ -623,62 +698,17 @@ pub struct StatsSummary<'a> {
     pub stats: &'a CleaningStats,
 }
 
-#[allow(dead_code)]
-/// Clean buffered line-stream input and write cleaned output incrementally.
-///
-/// # Arguments
-/// - `reader`: Source stream, read line-by-line.
-/// - `writer`: Destination stream for cleaned chunks.
-/// - `cleaner`: Reusable cleaner configuration.
-///
-/// # Returns
-/// Aggregate streaming stats and total change count.
-///
-/// # Errors
-/// Returns an error if reading, writing, or flushing streams fails.
-pub fn clean_stream<R, W>(
-    reader: &mut R,
-    writer: &mut W,
-    cleaner: &TextCleaner,
-) -> Result<StreamOutcome>
-where
-    R: BufRead,
-    W: Write,
-{
-    let mut stream = StreamCleaner::new(cleaner.options().clone());
-    let mut buffer = String::new();
-    let mut chunk_output = String::new();
-
-    loop {
-        buffer.clear();
-        let bytes_read = reader
-            .read_line(&mut buffer)
-            .context("failed to read input stream")?;
-        if bytes_read == 0 {
-            break;
-        }
-        if let Some(result) = stream.feed(&buffer, &mut chunk_output) {
-            writer
-                .write_all(result.text.as_bytes())
-                .context("failed to write stream chunk")?;
-            chunk_output.clear();
-        }
+fn validate_keyboard_only_dependency(
+    options: &CleaningOptions,
+    dependent_flag_specified_by_user: bool,
+    flag_label: &str,
+) -> Result<()> {
+    if dependent_flag_specified_by_user && !options.keyboard_only {
+        bail!(
+            "{flag_label} requires keyboard-only mode; set '--keyboard-only true' or remove the {flag_label} flag"
+        );
     }
-
-    if let Some(result) = stream.finish(&mut chunk_output) {
-        writer
-            .write_all(result.text.as_bytes())
-            .context("failed to write stream chunk")?;
-        chunk_output.clear();
-    }
-
-    writer.flush().context("failed to flush output stream")?;
-
-    let summary = stream.summary();
-    Ok(StreamOutcome {
-        stats: summary.stats,
-        changes_made: summary.changes_made,
-    })
+    Ok(())
 }
 
 /// Serialize JSON stats payload and append a trailing newline.
@@ -702,122 +732,4 @@ pub fn write_stats_json<W: Write>(writer: &mut W, summary: &StatsSummary) -> Res
         .flush()
         .context("failed to flush JSON stats output")?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io;
-
-    #[test]
-    fn cli_defaults_match_library_defaults() {
-        let cli_defaults = default_cli_options();
-        let library_defaults = CleaningOptions::default();
-        assert_eq!(
-            cli_defaults, library_defaults,
-            "CLI default options should mirror library defaults"
-        );
-    }
-
-    #[test]
-    fn config_rejects_unknown_option_fields() {
-        let bad = r#"
-version = 1
-[options]
-keyboard_only = true
-normalise_spaces = false
-"#;
-        let err = toml::from_str::<ConfigFile>(bad).expect_err("unknown fields should fail");
-        assert!(
-            err.to_string().contains("unknown field"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn emoji_policy_dependency_requires_keyboard_mode_when_explicit() {
-        let mut options = default_cli_options();
-        options.keyboard_only = false;
-        let err = validate_emoji_policy_dependency(&options, true)
-            .expect_err("explicit emoji policy must require keyboard mode");
-        assert!(
-            err.to_string().contains("keyboard-only mode"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn non_ascii_policy_dependency_requires_keyboard_mode_when_explicit() {
-        let mut options = default_cli_options();
-        options.keyboard_only = false;
-        let err = validate_non_ascii_policy_dependency(&options, true)
-            .expect_err("explicit non-ASCII policy must require keyboard mode");
-        assert!(
-            err.to_string().contains("keyboard-only mode"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn extended_keyboard_dependency_requires_keyboard_mode_when_explicit() {
-        let mut options = default_cli_options();
-        options.keyboard_only = false;
-        let err = validate_extended_keyboard_dependency(&options, true)
-            .expect_err("explicit extended keyboard mode must require keyboard mode");
-        assert!(
-            err.to_string().contains("keyboard-only mode"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn code_safe_preset_matches_library_preset() {
-        assert_eq!(
-            options_from_preset(PresetArg::CodeSafe),
-            CleaningOptions::code_safe()
-        );
-    }
-
-    #[test]
-    fn write_stats_json_emits_trailing_newline() {
-        let stats = CleaningStats::default();
-        let summary = StatsSummary {
-            changed: false,
-            changes_made: 0,
-            stats: &stats,
-        };
-
-        let mut out = Vec::<u8>::new();
-        write_stats_json(&mut out, &summary).expect("JSON stats should serialize");
-        assert_eq!(out.last(), Some(&b'\n'));
-    }
-
-    struct FlushErrorWriter;
-
-    impl Write for FlushErrorWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Err(io::Error::new(io::ErrorKind::BrokenPipe, "flush failed"))
-        }
-    }
-
-    #[test]
-    fn write_stats_json_propagates_flush_errors() {
-        let stats = CleaningStats::default();
-        let summary = StatsSummary {
-            changed: true,
-            changes_made: 1,
-            stats: &stats,
-        };
-        let mut out = FlushErrorWriter;
-        let err = write_stats_json(&mut out, &summary).expect_err("flush errors should surface");
-        assert!(
-            err.to_string()
-                .contains("failed to flush JSON stats output"),
-            "unexpected error: {err}"
-        );
-    }
 }

--- a/src/bin/common/mod.rs
+++ b/src/bin/common/mod.rs
@@ -337,6 +337,9 @@ pub struct SharedCliOptions {
 
 impl SharedCliOptions {
     /// Convert shared CLI flags into sparse option overrides.
+    ///
+    /// # Returns
+    /// A [`PartialOptions`] value containing only user-provided overrides.
     pub fn to_partial_options(&self) -> PartialOptions {
         let mut partial = PartialOptions {
             remove_hidden: self.remove_hidden,
@@ -368,16 +371,25 @@ impl SharedCliOptions {
     }
 
     /// Whether emoji policy controls were explicitly specified.
+    ///
+    /// # Returns
+    /// `true` if `--keep-emoji` or `--emoji-policy` was provided.
     pub fn emoji_policy_specified_by_user(&self) -> bool {
         self.keep_emoji || self.emoji_policy.is_some()
     }
 
     /// Whether non-ASCII policy was explicitly specified.
+    ///
+    /// # Returns
+    /// `true` if `--non-ascii-policy` was provided.
     pub fn non_ascii_policy_specified_by_user(&self) -> bool {
         self.non_ascii_policy.is_some()
     }
 
     /// Whether extended keyboard mode was explicitly specified.
+    ///
+    /// # Returns
+    /// `true` if `--extended-keyboard` was provided.
     pub fn extended_keyboard_specified_by_user(&self) -> bool {
         self.extended_keyboard.is_some()
     }

--- a/src/bin/ishuman.rs
+++ b/src/bin/ishuman.rs
@@ -9,11 +9,10 @@ use anyhow::{Context, Result};
 use clap::{ArgAction, Parser};
 
 use common::{
-    default_cli_options, default_config_path, load_config, options_from_preset, parse_bool_flag,
-    read_input, validate_emoji_policy_dependency, validate_extended_keyboard_dependency,
-    validate_non_ascii_policy_dependency, write_stats, write_stats_json, EmojiPolicyArg,
-    LineEndingChoice, NonAsciiPolicyArg, PartialOptions, PresetArg, StatsSummary,
-    UnicodeNormalizationChoice, MAX_INPUT_BYTES,
+    default_cli_options, default_config_path, load_config, options_from_preset, read_input,
+    validate_emoji_policy_dependency, validate_extended_keyboard_dependency,
+    validate_non_ascii_policy_dependency, write_stats, write_stats_json, SharedCliOptions,
+    StatsSummary, MAX_INPUT_BYTES,
 };
 use rehuman::TextCleaner;
 
@@ -25,7 +24,7 @@ fn main() -> Result<()> {
 fn run() -> Result<i32> {
     let cli = Cli::parse();
 
-    let config_path = cli.config.clone().or_else(default_config_path);
+    let config_path = cli.shared.config.clone().or_else(default_config_path);
 
     let mut options = default_cli_options();
 
@@ -36,15 +35,21 @@ fn run() -> Result<i32> {
         }
     }
 
-    if let Some(preset) = cli.preset {
+    if let Some(preset) = cli.shared.preset {
         options = options_from_preset(preset);
     }
 
-    let overrides = cli.to_partial_options();
+    let overrides = cli.shared.to_partial_options();
     overrides.apply_to(&mut options);
-    validate_emoji_policy_dependency(&options, cli.keep_emoji || cli.emoji_policy.is_some())?;
-    validate_non_ascii_policy_dependency(&options, cli.non_ascii_policy.is_some())?;
-    validate_extended_keyboard_dependency(&options, cli.extended_keyboard.is_some())?;
+    validate_emoji_policy_dependency(&options, cli.shared.emoji_policy_specified_by_user())?;
+    validate_non_ascii_policy_dependency(
+        &options,
+        cli.shared.non_ascii_policy_specified_by_user(),
+    )?;
+    validate_extended_keyboard_dependency(
+        &options,
+        cli.shared.extended_keyboard_specified_by_user(),
+    )?;
 
     let input = read_input(cli.input.as_deref(), MAX_INPUT_BYTES)?;
 
@@ -82,82 +87,8 @@ struct Cli {
     #[arg(value_name = "INPUT")]
     input: Option<PathBuf>,
 
-    /// Apply a named preset (for example `code-safe` for docs/source text).
-    #[arg(long, value_enum)]
-    preset: Option<PresetArg>,
-
-    /// Override remove_hidden behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    remove_hidden: Option<bool>,
-
-    /// Override remove_trailing_whitespace behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    remove_trailing_whitespace: Option<bool>,
-
-    /// Override normalize_spaces behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    normalize_spaces: Option<bool>,
-
-    /// Override normalize_dashes behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    normalize_dashes: Option<bool>,
-
-    /// Override normalize_quotes behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    normalize_quotes: Option<bool>,
-
-    /// Override normalize_other behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    normalize_other: Option<bool>,
-
-    /// Override keyboard_only behavior (true/false, default true for CLI)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    keyboard_only: Option<bool>,
-
-    /// Allow a curated non-ASCII keyboard allowlist in keyboard-only mode.
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    extended_keyboard: Option<bool>,
-
-    /// Allow emoji to pass through even when keyboard_only is enabled
-    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "emoji_policy")]
-    keep_emoji: bool,
-
-    /// Explicit emoji policy (drop or keep)
-    #[arg(long, value_enum)]
-    emoji_policy: Option<EmojiPolicyArg>,
-
-    /// Non-ASCII handling in keyboard-only mode (drop/fold/transliterate).
-    #[arg(long, value_enum)]
-    non_ascii_policy: Option<NonAsciiPolicyArg>,
-
-    /// Preserve ZWJ/ZWNJ joiners even when hidden characters are removed.
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    preserve_joiners: Option<bool>,
-
-    /// Override remove_control_chars behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    remove_control_chars: Option<bool>,
-
-    /// Override collapse_whitespace behavior (true/false, default false)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    collapse_whitespace: Option<bool>,
-
-    /// Line ending normalization strategy (auto = preserve input)
-    #[arg(long, value_enum)]
-    line_endings: Option<LineEndingChoice>,
-
-    /// Unicode normalization mode (none/NFD/NFC/NFKD/NFKC)
-    #[arg(long, value_enum)]
-    unicode_normalization: Option<UnicodeNormalizationChoice>,
-
-    /// Strip bidi control characters (true/false, default false)
-    #[cfg(feature = "security")]
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    strip_bidi_controls: Option<bool>,
-
-    /// Path to config file. Defaults to platform config directory.
-    #[arg(long, value_name = "PATH")]
-    config: Option<PathBuf>,
+    #[command(flatten)]
+    shared: SharedCliOptions,
 
     /// Print a summary of potential transformations to stderr.
     #[arg(long, short = 's', action = ArgAction::SetTrue)]
@@ -166,96 +97,4 @@ struct Cli {
     /// Emit a JSON summary of potential transformations to stdout.
     #[arg(long = "json", action = ArgAction::SetTrue)]
     stats_json: bool,
-}
-
-impl Cli {
-    fn to_partial_options(&self) -> PartialOptions {
-        let mut partial = PartialOptions {
-            remove_hidden: self.remove_hidden,
-            remove_trailing_whitespace: self.remove_trailing_whitespace,
-            normalize_spaces: self.normalize_spaces,
-            normalize_dashes: self.normalize_dashes,
-            normalize_quotes: self.normalize_quotes,
-            normalize_other: self.normalize_other,
-            keyboard_only: self.keyboard_only,
-            extended_keyboard: self.extended_keyboard,
-            emoji_policy: None,
-            non_ascii_policy: self.non_ascii_policy,
-            preserve_joiners: self.preserve_joiners,
-            remove_control_chars: self.remove_control_chars,
-            collapse_whitespace: self.collapse_whitespace,
-            line_endings: self.line_endings,
-            unicode_normalization: self.unicode_normalization,
-            #[cfg(feature = "security")]
-            strip_bidi_controls: self.strip_bidi_controls,
-        };
-
-        if self.keep_emoji {
-            partial.emoji_policy = Some(EmojiPolicyArg::Keep);
-        } else if let Some(policy) = self.emoji_policy {
-            partial.emoji_policy = Some(policy);
-        }
-
-        partial
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn emoji_policy_requires_keyboard_mode_when_explicit() {
-        let cli = Cli::try_parse_from([
-            "ishuman",
-            "--keyboard-only",
-            "false",
-            "--emoji-policy",
-            "drop",
-            "input.txt",
-        ])
-        .expect("args should parse");
-        let mut options = default_cli_options();
-        cli.to_partial_options().apply_to(&mut options);
-        let check = validate_emoji_policy_dependency(
-            &options,
-            cli.keep_emoji || cli.emoji_policy.is_some(),
-        );
-        assert!(check.is_err(), "dependency check should fail");
-    }
-
-    #[test]
-    fn non_ascii_policy_requires_keyboard_mode_when_explicit() {
-        let cli = Cli::try_parse_from([
-            "ishuman",
-            "--keyboard-only",
-            "false",
-            "--non-ascii-policy",
-            "transliterate",
-            "input.txt",
-        ])
-        .expect("args should parse");
-        let mut options = default_cli_options();
-        cli.to_partial_options().apply_to(&mut options);
-        let check = validate_non_ascii_policy_dependency(&options, cli.non_ascii_policy.is_some());
-        assert!(check.is_err(), "dependency check should fail");
-    }
-
-    #[test]
-    fn extended_keyboard_requires_keyboard_mode_when_explicit() {
-        let cli = Cli::try_parse_from([
-            "ishuman",
-            "--keyboard-only",
-            "false",
-            "--extended-keyboard",
-            "true",
-            "input.txt",
-        ])
-        .expect("args should parse");
-        let mut options = default_cli_options();
-        cli.to_partial_options().apply_to(&mut options);
-        let check =
-            validate_extended_keyboard_dependency(&options, cli.extended_keyboard.is_some());
-        assert!(check.is_err(), "dependency check should fail");
-    }
 }

--- a/src/bin/rehuman.rs
+++ b/src/bin/rehuman.rs
@@ -320,6 +320,7 @@ struct Cli {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
 
     #[test]
     fn clap_rejects_stream_and_inplace_together() {
@@ -331,5 +332,47 @@ mod tests {
     fn clap_rejects_print_config_with_processing_flags() {
         let parsed = Cli::try_parse_from(["rehuman", "--print-config", "--stats"]);
         assert!(parsed.is_err(), "expected clap conflict error");
+    }
+
+    #[test]
+    fn write_stats_json_emits_trailing_newline() {
+        let stats = CleaningStats::default();
+        let summary = StatsSummary {
+            changed: false,
+            changes_made: 0,
+            stats: &stats,
+        };
+        let mut out = Vec::<u8>::new();
+        write_stats_json(&mut out, &summary).expect("JSON stats should serialize");
+        assert_eq!(out.last(), Some(&b'\n'));
+    }
+
+    struct FlushErrorWriter;
+
+    impl Write for FlushErrorWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "flush failed"))
+        }
+    }
+
+    #[test]
+    fn write_stats_json_propagates_flush_errors() {
+        let stats = CleaningStats::default();
+        let summary = StatsSummary {
+            changed: true,
+            changes_made: 1,
+            stats: &stats,
+        };
+        let mut out = FlushErrorWriter;
+        let err = write_stats_json(&mut out, &summary).expect_err("flush errors should surface");
+        assert!(
+            err.to_string()
+                .contains("failed to flush JSON stats output"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/bin/rehuman.rs
+++ b/src/bin/rehuman.rs
@@ -4,7 +4,7 @@ mod common;
 
 use std::borrow::Cow;
 use std::fs;
-use std::io::{self, BufReader, BufWriter, IsTerminal};
+use std::io::{self, BufRead, BufReader, BufWriter, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
@@ -12,19 +12,17 @@ use clap::{ArgAction, Parser};
 use tempfile::NamedTempFile;
 
 use common::{
-    clean_stream, default_cli_options, default_config_path, load_config, options_from_preset,
-    parse_bool_flag, read_input, save_config, validate_emoji_policy_dependency,
-    validate_extended_keyboard_dependency, validate_non_ascii_policy_dependency, write_output,
-    write_stats, write_stats_json, ConfigFile, EmojiPolicyArg, LineEndingChoice, NonAsciiPolicyArg,
-    PartialOptions, PresetArg, SerializableOptions, StatsSummary, UnicodeNormalizationChoice,
-    CONFIG_VERSION, MAX_INPUT_BYTES,
+    default_cli_options, default_config_path, load_config, options_from_preset, read_input,
+    validate_emoji_policy_dependency, validate_extended_keyboard_dependency,
+    validate_non_ascii_policy_dependency, write_stats, write_stats_json, ConfigFile,
+    SerializableOptions, SharedCliOptions, StatsSummary, CONFIG_VERSION, MAX_INPUT_BYTES,
 };
-use rehuman::{CleaningResult, TextCleaner};
+use rehuman::{CleaningResult, CleaningStats, StreamCleaner, TextCleaner};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let config_path = cli.config.clone().or_else(default_config_path);
+    let config_path = cli.shared.config.clone().or_else(default_config_path);
 
     if cli.reset_config {
         if let Some(ref path) = config_path {
@@ -48,15 +46,21 @@ fn main() -> Result<()> {
         }
     }
 
-    if let Some(preset) = cli.preset {
+    if let Some(preset) = cli.shared.preset {
         options = options_from_preset(preset);
     }
 
-    let overrides = cli.to_partial_options();
+    let overrides = cli.shared.to_partial_options();
     overrides.apply_to(&mut options);
-    validate_emoji_policy_dependency(&options, cli.keep_emoji || cli.emoji_policy.is_some())?;
-    validate_non_ascii_policy_dependency(&options, cli.non_ascii_policy.is_some())?;
-    validate_extended_keyboard_dependency(&options, cli.extended_keyboard.is_some())?;
+    validate_emoji_policy_dependency(&options, cli.shared.emoji_policy_specified_by_user())?;
+    validate_non_ascii_policy_dependency(
+        &options,
+        cli.shared.non_ascii_policy_specified_by_user(),
+    )?;
+    validate_extended_keyboard_dependency(
+        &options,
+        cli.shared.extended_keyboard_specified_by_user(),
+    )?;
 
     if cli.save_config {
         if let Some(ref path) = config_path {
@@ -179,6 +183,79 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
+struct StreamOutcome {
+    stats: CleaningStats,
+    changes_made: u64,
+}
+
+fn save_config(path: &Path, options: &rehuman::CleaningOptions) -> Result<()> {
+    let cfg = ConfigFile {
+        version: CONFIG_VERSION,
+        options: SerializableOptions::from_cleaning_options(options),
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create config directory {}", parent.display()))?;
+    }
+    let data = toml::to_string_pretty(&cfg)?;
+    fs::write(path, data)?;
+    Ok(())
+}
+
+fn write_output(result: &CleaningResult<'_>) -> Result<()> {
+    let mut stdout = io::stdout().lock();
+    stdout
+        .write_all(result.text.as_bytes())
+        .context("failed to write to stdout")?;
+    Ok(())
+}
+
+fn clean_stream<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    cleaner: &TextCleaner,
+) -> Result<StreamOutcome>
+where
+    R: BufRead,
+    W: Write,
+{
+    let mut stream = StreamCleaner::new(cleaner.options().clone());
+    let mut buffer = String::new();
+    let mut chunk_output = String::new();
+
+    loop {
+        buffer.clear();
+        let bytes_read = reader
+            .read_line(&mut buffer)
+            .context("failed to read input stream")?;
+        if bytes_read == 0 {
+            break;
+        }
+        if let Some(result) = stream.feed(&buffer, &mut chunk_output) {
+            writer
+                .write_all(result.text.as_bytes())
+                .context("failed to write stream chunk")?;
+            chunk_output.clear();
+        }
+    }
+
+    if let Some(result) = stream.finish(&mut chunk_output) {
+        writer
+            .write_all(result.text.as_bytes())
+            .context("failed to write stream chunk")?;
+        chunk_output.clear();
+    }
+
+    writer.flush().context("failed to flush output stream")?;
+
+    let summary = stream.summary();
+    Ok(StreamOutcome {
+        stats: summary.stats,
+        changes_made: summary.changes_made,
+    })
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "rehuman",
@@ -191,82 +268,8 @@ struct Cli {
     #[arg(value_name = "INPUT")]
     input: Option<PathBuf>,
 
-    /// Apply a named preset (for example `code-safe` for docs/source text).
-    #[arg(long, value_enum)]
-    preset: Option<PresetArg>,
-
-    /// Override remove_hidden behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    remove_hidden: Option<bool>,
-
-    /// Override remove_trailing_whitespace behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    remove_trailing_whitespace: Option<bool>,
-
-    /// Override normalize_spaces behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    normalize_spaces: Option<bool>,
-
-    /// Override normalize_dashes behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    normalize_dashes: Option<bool>,
-
-    /// Override normalize_quotes behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    normalize_quotes: Option<bool>,
-
-    /// Override normalize_other behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    normalize_other: Option<bool>,
-
-    /// Override keyboard_only behavior (true/false, default true for CLI)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    keyboard_only: Option<bool>,
-
-    /// Allow a curated non-ASCII keyboard allowlist in keyboard-only mode.
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    extended_keyboard: Option<bool>,
-
-    /// Allow emoji to pass through even when keyboard_only is enabled
-    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "emoji_policy")]
-    keep_emoji: bool,
-
-    /// Explicit emoji policy (drop or keep)
-    #[arg(long, value_enum)]
-    emoji_policy: Option<EmojiPolicyArg>,
-
-    /// Non-ASCII handling in keyboard-only mode (drop/fold/transliterate).
-    #[arg(long, value_enum)]
-    non_ascii_policy: Option<NonAsciiPolicyArg>,
-
-    /// Preserve ZWJ/ZWNJ joiners even when hidden characters are removed.
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    preserve_joiners: Option<bool>,
-
-    /// Override remove_control_chars behavior (true/false, default true)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    remove_control_chars: Option<bool>,
-
-    /// Override collapse_whitespace behavior (true/false, default false)
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    collapse_whitespace: Option<bool>,
-
-    /// Line ending normalization strategy (auto = preserve input)
-    #[arg(long, value_enum)]
-    line_endings: Option<LineEndingChoice>,
-
-    /// Unicode normalization mode (none/NFD/NFC/NFKD/NFKC)
-    #[arg(long, value_enum)]
-    unicode_normalization: Option<UnicodeNormalizationChoice>,
-
-    /// Strip bidi control characters (true/false, default false)
-    #[cfg(feature = "security")]
-    #[arg(long, value_name = "BOOL", value_parser = parse_bool_flag, default_missing_value = "true", num_args = 0..=1)]
-    strip_bidi_controls: Option<bool>,
-
-    /// Path to config file. Defaults to platform config directory.
-    #[arg(long, value_name = "PATH")]
-    config: Option<PathBuf>,
+    #[command(flatten)]
+    shared: SharedCliOptions,
 
     /// Persist the resolved configuration back to the config file.
     #[arg(long, action = ArgAction::SetTrue)]
@@ -314,38 +317,6 @@ struct Cli {
     inplace: bool,
 }
 
-impl Cli {
-    fn to_partial_options(&self) -> PartialOptions {
-        let mut partial = PartialOptions {
-            remove_hidden: self.remove_hidden,
-            remove_trailing_whitespace: self.remove_trailing_whitespace,
-            normalize_spaces: self.normalize_spaces,
-            normalize_dashes: self.normalize_dashes,
-            normalize_quotes: self.normalize_quotes,
-            normalize_other: self.normalize_other,
-            keyboard_only: self.keyboard_only,
-            extended_keyboard: self.extended_keyboard,
-            emoji_policy: None,
-            non_ascii_policy: self.non_ascii_policy,
-            preserve_joiners: self.preserve_joiners,
-            remove_control_chars: self.remove_control_chars,
-            collapse_whitespace: self.collapse_whitespace,
-            line_endings: self.line_endings,
-            unicode_normalization: self.unicode_normalization,
-            #[cfg(feature = "security")]
-            strip_bidi_controls: self.strip_bidi_controls,
-        };
-
-        if self.keep_emoji {
-            partial.emoji_policy = Some(EmojiPolicyArg::Keep);
-        } else if let Some(policy) = self.emoji_policy {
-            partial.emoji_policy = Some(policy);
-        }
-
-        partial
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -360,60 +331,5 @@ mod tests {
     fn clap_rejects_print_config_with_processing_flags() {
         let parsed = Cli::try_parse_from(["rehuman", "--print-config", "--stats"]);
         assert!(parsed.is_err(), "expected clap conflict error");
-    }
-
-    #[test]
-    fn emoji_policy_requires_keyboard_mode_when_explicit() {
-        let cli = Cli::try_parse_from([
-            "rehuman",
-            "--keyboard-only",
-            "false",
-            "--emoji-policy",
-            "drop",
-            "input.txt",
-        ])
-        .expect("args should parse");
-        let mut options = default_cli_options();
-        cli.to_partial_options().apply_to(&mut options);
-        let check = validate_emoji_policy_dependency(
-            &options,
-            cli.keep_emoji || cli.emoji_policy.is_some(),
-        );
-        assert!(check.is_err(), "dependency check should fail");
-    }
-
-    #[test]
-    fn non_ascii_policy_requires_keyboard_mode_when_explicit() {
-        let cli = Cli::try_parse_from([
-            "rehuman",
-            "--keyboard-only",
-            "false",
-            "--non-ascii-policy",
-            "transliterate",
-            "input.txt",
-        ])
-        .expect("args should parse");
-        let mut options = default_cli_options();
-        cli.to_partial_options().apply_to(&mut options);
-        let check = validate_non_ascii_policy_dependency(&options, cli.non_ascii_policy.is_some());
-        assert!(check.is_err(), "dependency check should fail");
-    }
-
-    #[test]
-    fn extended_keyboard_requires_keyboard_mode_when_explicit() {
-        let cli = Cli::try_parse_from([
-            "rehuman",
-            "--keyboard-only",
-            "false",
-            "--extended-keyboard",
-            "true",
-            "input.txt",
-        ])
-        .expect("args should parse");
-        let mut options = default_cli_options();
-        cli.to_partial_options().apply_to(&mut options);
-        let check =
-            validate_extended_keyboard_dependency(&options, cli.extended_keyboard.is_some());
-        assert!(check.is_err(), "dependency check should fail");
     }
 }


### PR DESCRIPTION
focused cleanup pass: it removes duplicated CLI option handling between `rehuman` and `ishuman`, consolidates dependency validation paths, and tightens docs wording where users were still getting confused (`clean()` vs `humanize()` in Python).

The goal was to reduce drift risk and complexity without changing intended behavior. The CLI surface remains the same; the internals are just less fragmented and easier to maintain.

## Validation
Ran:

```bash
cargo test --workspace --all-features
```

Everything passed across library, bin, contract, and property tests.

## Commits
- `82979e8` refactor(cli): consolidate shared args and trim redundant test paths
- `e5053e6` test(cli): keep single-source stats-json writer coverage
- `92dcc3b` docs: dedupe python docs and clarify helper behavior