### PR TITLE
chore(release): bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rehuman"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "rehuman-python"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "pyo3",
  "rehuman",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [package]
 name = "rehuman"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Peter Szemraj <peterszemraj+dev@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the Rust library crate:
 
 ```toml
 [dependencies]
-rehuman = "0.1.2" # replace with the latest published version
+rehuman = "0.1.3" # replace with the latest published version
 ```
 
 Install CLI binaries (`rehuman`, `ishuman`):

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rehuman-python"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.82"
 publish = false

--- a/python/docs/release.md
+++ b/python/docs/release.md
@@ -107,7 +107,7 @@ trigger PyPI publication for that release.
 Build/re-attach release artifacts for existing tag:
 
 - Dispatch `python-release-artifacts.yml`
-- Input `tag: v0.1.2` (or `0.1.2`)
+- Input `tag: v0.1.3` (or `0.1.3`)
 - Input `test_mode: false`
 - Input `confirm_release_upload: true`
 
@@ -122,7 +122,7 @@ Dry-run build on a branch without uploading release assets:
 Re-publish existing release artifacts to PyPI (idempotent):
 
 - Dispatch `python-pypi-publish.yml`
-- Input `tag: v0.1.2` (or `0.1.2`)
+- Input `tag: v0.1.3` (or `0.1.3`)
 - Optional prerelease override: `allow_prerelease: true`
 
 ## Troubleshooting


### PR DESCRIPTION
This PR is release prep only. It bumps project/package version references from 0.1.2 to 0.1.3 across Rust and Python manifests plus docs.

